### PR TITLE
Card Display and Selection

### DIFF
--- a/frontend/src/components/Card.jsx
+++ b/frontend/src/components/Card.jsx
@@ -1,20 +1,26 @@
 import './Card.css';
 
-export default function Card({card, onGuess, revealed}) {
+export default function Card({card, onGuess, revealed, canGuess}) {
     const handleClick = () => {
-        if (!revealed && onGuess) {
+        if (!revealed && canGuess) {
             onGuess();
         }
     };
 
     const getCardClass = () => {
-        if (!revealed) return 'card';
-        return `card card-${card.color}`
+        if (!card.type) return 'card';
+        const colorMap = { RED: 'red', BLUE: 'blue', NEUTRAL: 'neutral', ASSASSIN: 'black' };
+        const color = colorMap[card.type];
+        return `card card-${color}`;
     };
 
     return (
-        <div className={getCardClass()} onClick={handleClick}>
-            <span>{card.word}</span>
+        <div 
+            className={getCardClass()} 
+            onClick={handleClick}
+            style={{ cursor: (revealed || !canGuess) ? 'default' : 'pointer' }}
+        >
+            {card.word && <span>{card.word}</span>}
         </div>
     )
 }

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { api } from '../services/api';
 import Card from '../components/Card';
 import { useParams } from 'react-router-dom';
@@ -13,22 +13,30 @@ function GamePage() {
     const [players, setPlayers] = useState([]);
     const [clueWord, setClueWord] = useState('');
     const [clueNumber, setClueNumber] = useState(1);
+    const spymasterModeRef = useRef(spymasterMode);
+    
     const currentPlayer = players.find(player => String(player.playerId) === String(playerId));
     const isMyTurn = currentPlayer?.red === game?.redTurn;
     const isSpymaster = currentPlayer?.spymaster;
+    const canGuess = game?.turnPhase === 'GUESS' && isMyTurn && !isSpymaster;
 
-    useGameSocket(gameId, (gameData) => {
-        setGame(gameData);
-    });
-
+    //toggle spymasterMode when we learn the player's role
     useEffect(() => {
-        loadGame(gameId);
-    }, [gameId]);
+        if (isSpymaster !== undefined) {
+            setSpymasterMode(isSpymaster);
+            spymasterModeRef.current = isSpymaster;
+        }
+    }, [isSpymaster]);
 
-    const loadGame = async (id) => {
+    //keep ref in sync with state
+    useEffect(() => {
+        spymasterModeRef.current = spymasterMode;
+    }, [spymasterMode]);
+
+    const loadGame = async (id, isSpy) => {
         try {
-            console.log('Fetching game data for ID:', id, 'with spymaster mode:', spymasterMode);
-            const gameData = await api.getGame(id, spymasterMode);
+            console.log('Fetching game data for ID:', id, 'with spymaster mode:', isSpy);
+            const gameData = await api.getGame(id, isSpy);
             console.log('Game data:', gameData);
             setGame(gameData);
 
@@ -40,21 +48,29 @@ function GamePage() {
         }
     };
 
+    useGameSocket(gameId, () => {
+        loadGame(gameId, spymasterModeRef.current);
+    });
+
+    useEffect(() => {
+        loadGame(gameId, spymasterMode);
+    }, [gameId, spymasterMode]);
+
     const handleGuess = async (position) => {
-        await api.makeGuess(gameId, position);
-        await loadGame(gameId);
+        await api.makeGuess(gameId, position, playerId);
+        await loadGame(gameId, spymasterModeRef.current);
     };
 
     const handleSubmitClue = async () => {
         await api.submitClue(gameId, clueWord, clueNumber);
         setClueWord('');
         setClueNumber(1);
-        await loadGame(gameId);
+        await loadGame(gameId, spymasterModeRef.current);
     }
 
     const handlePassTurn = async () => {
         await api.passTurn(gameId);
-        await loadGame(gameId);
+        await loadGame(gameId, spymasterModeRef.current);
     }
 
     return (
@@ -115,14 +131,18 @@ function GamePage() {
 
             {game && (
                 <div className="board">
-                    {game.cards?.map((card, index) => (
-                        <Card
-                            key={index}
-                            card={card}
-                            revealed={card.revealed}
-                            onGuess={() => handleGuess(index)}
-                        />
-                    ))}
+                    {game.cards
+                        ?.slice()
+                        .sort((a, b) => a.position - b.position)
+                        .map((card) => (
+                            <Card
+                                key={card.position}
+                                card={card}
+                                revealed={card.revealed}
+                                canGuess={canGuess}
+                                onGuess={() => handleGuess(card.position)}
+                            />
+                        ))}
                 </div>
             )}
         </div>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -22,8 +22,8 @@ export const api = {
         });
         return response.json();
     },
-    makeGuess: async (id, position) => {
-        await fetch(`${API_URL}/game/${id}/guess/${position}`, {
+    makeGuess: async (id, position, playerId) => {
+        await fetch(`${API_URL}/game/${id}/guess/${position}?playerId=${playerId}`, {
             method: 'POST',
         });
     },

--- a/service/src/main/java/codenames/business/GameService.java
+++ b/service/src/main/java/codenames/business/GameService.java
@@ -100,7 +100,7 @@ public class GameService {
     }
 
     @Transactional
-    public void guess(Long gameId, int position) {
+    public void guess(Long gameId, int position, String playerId) {
         Game game = gameRepository.findById(gameId).orElseThrow(() -> new RuntimeException("Game not found"));
 
         if(game.getStatus() != Status.STARTED){
@@ -109,6 +109,14 @@ public class GameService {
 
         if(game.getTurnPhase() != TurnPhase.GUESS){
             throw new RuntimeException("Not guessing phase");
+        }
+
+        //make sure that the player making the guess is the guesser on the currently-going team
+        GamePlayer currentPlayer = gamePlayerRepository.findByGameAndPlayer_Id(game, playerId)
+                .orElseThrow(() -> new RuntimeException("Player not in game"));
+        
+        if (currentPlayer.isSpymaster() || currentPlayer.isRed() != game.getRedTurn()) {
+            throw new RuntimeException("You cannot make a guess at this time");
         }
 
         GameCard card = gameCardRepository.findByGameIdAndPosition(gameId, position).orElseThrow(() -> new RuntimeException("Card not found"));
@@ -225,9 +233,12 @@ public class GameService {
 
     public GameDTO toDTO(Game game, boolean isSpymaster) {
         List<CardDTO> cardsDTOs = game.getCards().stream().map(card -> new CardDTO(
-                card.getWord().toString(),
+                //if card is revealed, then set the word to null, since the card is now "flipped over"
+                //i.e. since the card is flipped, we no longer need the word, only the color
+                card.isRevealed() ? null : card.getWord().toString(),
                 card.isRevealed(),
-                isSpymaster ? card.getCardType().toString() : null,
+                //only give card type to spymaster, or if card is revealed
+                isSpymaster || card.isRevealed() ? card.getCardType().toString() : null,
                 card.getPosition()
         )).toList();
 

--- a/service/src/main/java/codenames/repository/GamePlayerRepository.java
+++ b/service/src/main/java/codenames/repository/GamePlayerRepository.java
@@ -13,4 +13,6 @@ public interface GamePlayerRepository extends JpaRepository<GamePlayer, Long> {
     boolean existsByGameAndPlayer(Game game, Player player);
 
     Optional<GamePlayer> findByGameAndPlayer(Game game, Player player);
+
+    Optional<GamePlayer> findByGameAndPlayer_Id(Game game, String playerId);
 }

--- a/service/src/main/java/codenames/webservice/WebserviceController.java
+++ b/service/src/main/java/codenames/webservice/WebserviceController.java
@@ -38,8 +38,8 @@ public class WebserviceController {
     }
 
     @PostMapping("/game/{id}/guess/{position}") // guesses word at position, sets that card as revealed and updates turn
-    public void guess(@PathVariable Long id, @PathVariable int position) {
-        gameService.guess(id, position);
+    public void guess(@PathVariable Long id, @PathVariable int position, @RequestParam String playerId) {
+        gameService.guess(id, position, playerId);
     }
 
     @PostMapping("/game/{id}/end")


### PR DESCRIPTION
Cards are now displayed with colors for spymasters and without colors for guessers. This is enforced in the backend, so only spymasters are able to retrieve card types for not-revealed cards. 

Card selection permissions are now enforced, and restricted to only the guesser on their turn. This is also enforced in the backend, with player ID now passed to the backend along with the guess request. 

Cards that are selected are now displayed with color for all players, and the word on the card is removed. This gives an easy way to indicate selected cards to the spymaster as well (since they already see the card with color), and the already-selected words are no longer needed anyway.